### PR TITLE
add ServiceExt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
 
   "examples/tcp-server",
   "examples/unix-server",
-  # "examples/native-tls-server",
-  # "examples/openssl-server",
-  # "examples/rustls-server",
+  "examples/native-tls-server",
+  "examples/openssl-server",
+  "examples/rustls-server",
 ]

--- a/examples/native-tls-server/Cargo.toml
+++ b/examples/native-tls-server/Cargo.toml
@@ -11,10 +11,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-izanami = { path = "../..", features = ["native-tls"] }
+izanami = { path = "../.." }
 failure = "0.1.3"
+futures = "0.1"
+http = "0.1"
 native-tls = "0.2"
 tokio-tls = "0.2"
-
-echo-service = { path = "../echo-service" }
-http = "0.1"

--- a/examples/openssl-server/Cargo.toml
+++ b/examples/openssl-server/Cargo.toml
@@ -11,8 +11,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-izanami = { path = "../..", features = ["openssl"] }
-openssl = "0.10"
-
-echo-service = { path = "../echo-service" }
+izanami = { path = "../.." }
+failure = "0.1"
+futures = "0.1"
 http = "0.1"
+openssl = "0.10"
+tokio-openssl = "0.3"

--- a/examples/openssl-server/src/main.rs
+++ b/examples/openssl-server/src/main.rs
@@ -1,30 +1,26 @@
 use {
-    echo_service::Echo,
+    futures::prelude::*,
     http::Response,
-    izanami::server::Server,
+    izanami::{
+        server::{Incoming, Server}, //
+        service::{service_fn_ok, ServiceExt},
+    },
     openssl::{
         pkey::PKey,
         ssl::{SslAcceptor, SslMethod},
         x509::X509,
     },
+    std::io,
+    tokio_openssl::SslAcceptorExt,
 };
 
 const CERTIFICATE: &[u8] = include_bytes!("../../../test/server-crt.pem");
 const PRIVATE_KEY: &[u8] = include_bytes!("../../../test/server-key.pem");
 
-fn main() {
-    let echo = Echo::builder()
-        .add_route("/", |_cx| {
-            Response::builder() //
-                .body("Hello")
-                .unwrap()
-        })
-        .unwrap() //
-        .build();
-
+fn main() -> io::Result<()> {
     let cert = X509::from_pem(CERTIFICATE).unwrap();
     let pkey = PKey::private_key_from_pem(PRIVATE_KEY).unwrap();
-    let ssl = {
+    let ssl_acceptor = {
         let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
         builder.set_certificate(&cert).unwrap();
         builder.set_private_key(&pkey).unwrap();
@@ -32,10 +28,25 @@ fn main() {
         builder.build()
     };
 
-    izanami::rt::run(
-        Server::bind_tcp("127.0.0.1:4000")
-            .unwrap()
-            .use_tls(ssl)
-            .serve(echo),
-    )
+    let incoming_service = Incoming::bind_tcp("127.0.0.1:5000")? //
+        .serve(service_fn_ok(|()| {
+            service_fn_ok(move |_req| {
+                Response::builder()
+                    .header("content-type", "text/plain")
+                    .body("Hello")
+                    .unwrap()
+            })
+        }))
+        .fixed_service()
+        .and_then(move |(service, stream, protocol)| {
+            ssl_acceptor
+                .accept_async(stream)
+                .map(|stream| (service, stream, protocol))
+                .map_err(Into::into)
+        });
+
+    let server = Server::new(incoming_service);
+    izanami::rt::run(server);
+
+    Ok(())
 }

--- a/examples/rustls-server/Cargo.toml
+++ b/examples/rustls-server/Cargo.toml
@@ -11,10 +11,8 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-izanami = { path = "../..", features = ["rustls"] }
+izanami = { path = "../.." }
 failure = "0.1.3"
-rustls = "0.14"
-tokio-rustls = "0.8"
-
-echo-service = { path = "../echo-service" }
+futures = "0.1"
 http = "0.1"
+tokio-rustls = "0.8"

--- a/examples/rustls-server/src/main.rs
+++ b/examples/rustls-server/src/main.rs
@@ -1,36 +1,33 @@
 use {
-    echo_service::Echo,
     failure::format_err,
+    futures::prelude::*,
     http::Response,
-    izanami::server::Server,
-    rustls::{NoClientAuth, ServerConfig},
-    std::io,
-    tokio_rustls::TlsAcceptor,
+    izanami::{
+        server::{Incoming, Server}, //
+        service::{service_fn_ok, ServiceExt},
+    },
+    std::{io, sync::Arc},
+    tokio_rustls::{
+        rustls::{NoClientAuth, ServerConfig},
+        TlsAcceptor,
+    },
 };
 
 const CERTIFICATE: &[u8] = include_bytes!("../../../test/server-crt.pem");
 const PRIVATE_KEY: &[u8] = include_bytes!("../../../test/server-key.pem");
 
 fn main() -> failure::Fallible<()> {
-    let echo = Echo::builder()
-        .add_route("/", |_cx| {
-            Response::builder() //
-                .body("Hello")
-                .unwrap()
-        })?
-        .build();
-
-    let rustls = {
+    let rustls_acceptor = TlsAcceptor::from({
         let certs = {
             let mut reader = io::BufReader::new(io::Cursor::new(CERTIFICATE));
-            ::rustls::internal::pemfile::certs(&mut reader)
+            tokio_rustls::rustls::internal::pemfile::certs(&mut reader)
                 .map_err(|_| format_err!("failed to read certificate file"))?
         };
 
         let priv_key = {
             let mut reader = io::BufReader::new(io::Cursor::new(PRIVATE_KEY));
             let rsa_keys = {
-                ::rustls::internal::pemfile::rsa_private_keys(&mut reader)
+                tokio_rustls::rustls::internal::pemfile::rsa_private_keys(&mut reader)
                     .map_err(|_| format_err!("failed to read private key file as RSA"))?
             };
             rsa_keys
@@ -42,13 +39,28 @@ fn main() -> failure::Fallible<()> {
         let mut config = ServerConfig::new(NoClientAuth::new());
         config.set_single_cert(certs, priv_key)?;
 
-        TlsAcceptor::from(std::sync::Arc::new(config))
-    };
+        Arc::new(config)
+    });
 
-    izanami::rt::run(
-        Server::bind_tcp("127.0.0.1:4000")? //
-            .use_tls(rustls)
-            .serve(echo),
-    );
+    let incoming_service = Incoming::bind_tcp("127.0.0.1:5000")? //
+        .serve(service_fn_ok(|()| {
+            service_fn_ok(move |_req| {
+                Response::builder()
+                    .header("content-type", "text/plain")
+                    .body("Hello")
+                    .unwrap()
+            })
+        }))
+        .fixed_service()
+        .and_then(move |(service, stream, protocol)| {
+            rustls_acceptor
+                .accept(stream)
+                .map(|stream| (service, stream, protocol))
+                .map_err(Into::into)
+        });
+
+    let server = Server::new(incoming_service);
+    izanami::rt::run(server);
+
     Ok(())
 }

--- a/examples/tcp-server/src/main.rs
+++ b/examples/tcp-server/src/main.rs
@@ -2,23 +2,27 @@ use {
     http::Response,
     izanami::{
         server::{Incoming, Server}, //
-        service::service_fn_ok,
+        service::{service_fn_ok, ServiceExt},
     },
     std::io,
 };
 
 fn main() -> io::Result<()> {
-    let service = service_fn_ok(|()| {
-        service_fn_ok(|_req| {
-            Response::builder()
-                .header("content-type", "text/plain")
-                .body("Hello")
-                .unwrap()
-        })
-    });
-
     let incoming_service = Incoming::bind_tcp("127.0.0.1:5000")? //
-        .serve(service);
+        .serve(izanami::service::unit())
+        .fixed_service()
+        .map(|((), stream, protocol)| {
+            let remote_addr = stream.remote_addr();
+            let service = service_fn_ok(move |_req| {
+                eprintln!("remote_addr = {}", remote_addr);
+                Response::builder()
+                    .header("content-type", "text/plain")
+                    .body("Hello")
+                    .unwrap()
+            });
+
+            (service, stream, protocol)
+        });
 
     let server = Server::new(incoming_service);
     izanami::rt::run(server);

--- a/izanami-service/src/ext.rs
+++ b/izanami-service/src/ext.rs
@@ -1,0 +1,138 @@
+//! Extension for `Service`s.
+
+mod and_then;
+mod err_into;
+mod map;
+mod map_err;
+
+pub use self::{
+    and_then::AndThen, //
+    err_into::ErrInto,
+    map::Map,
+    map_err::MapErr,
+};
+
+use {
+    crate::Service, //
+    futures::{IntoFuture, Poll},
+    std::marker::PhantomData,
+};
+
+/// A `Service` that fixes request type to the specified one.
+#[derive(Debug)]
+pub struct FixedService<S, Req>
+where
+    S: Service<Req>,
+{
+    inner: S,
+    _marker: PhantomData<fn(Req)>,
+}
+
+impl<S, Req> FixedService<S, Req>
+where
+    S: Service<Req>,
+{
+    /// Modifies the inner service to map the response value into a different type using the specified function.
+    pub fn map<F, Res>(self, f: F) -> FixedService<Map<S, F>, Req>
+    where
+        F: Fn(S::Response) -> Res + Clone,
+    {
+        FixedService {
+            inner: Map {
+                service: self.inner,
+                f,
+            },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Modifies the inner service to map the error into a different type using the specified function.
+    pub fn map_err<F, E>(self, f: F) -> FixedService<MapErr<S, F>, Req>
+    where
+        F: Fn(S::Error) -> E + Clone,
+    {
+        FixedService {
+            inner: MapErr {
+                service: self.inner,
+                f,
+            },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Modifies the inner service to map the error value into the specified type.
+    pub fn err_into<E>(self) -> FixedService<ErrInto<S, E>, Req>
+    where
+        S::Error: Into<E>,
+    {
+        FixedService {
+            inner: ErrInto {
+                service: self.inner,
+                _marker: PhantomData,
+            },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Modifies the inner service to execute the future returned from the specified function on success.
+    pub fn and_then<F, R>(self, f: F) -> FixedService<AndThen<S, F>, Req>
+    where
+        F: Fn(S::Response) -> R + Clone,
+        R: IntoFuture<Error = S::Error>,
+    {
+        FixedService {
+            inner: AndThen {
+                service: self.inner,
+                f,
+            },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the inner `Service`.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S, Req> Service<Req> for FixedService<S, Req>
+where
+    S: Service<Req>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    #[inline]
+    fn call(&mut self, request: Req) -> Self::Future {
+        self.inner.call(request)
+    }
+}
+
+/// A set of extensions for `Service`s.
+///
+/// The implementation of this trait is provided for *all* types, but only
+/// the types that has implementation of `Service<Request>` can use the provided
+/// extensions from this trait.
+pub trait ServiceExt {
+    /// Fix the request type of this service to the specified one.
+    ///
+    /// At the same time, this method wraps the service with `FixedService`
+    /// to provide some adapter methods.
+    fn fixed_service<Req>(self) -> FixedService<Self, Req>
+    where
+        Self: Service<Req> + Sized,
+    {
+        FixedService {
+            inner: self,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S> ServiceExt for S {}

--- a/izanami-service/src/ext/and_then.rs
+++ b/izanami-service/src/ext/and_then.rs
@@ -1,0 +1,31 @@
+#![allow(missing_docs)]
+
+use {
+    crate::Service,
+    futures::{future, Future, IntoFuture, Poll},
+};
+
+#[derive(Debug)]
+pub struct AndThen<S, F> {
+    pub(super) service: S,
+    pub(super) f: F,
+}
+
+impl<S, F, R, Req> Service<Req> for AndThen<S, F>
+where
+    S: Service<Req>,
+    F: Fn(S::Response) -> R + Clone,
+    R: IntoFuture<Error = S::Error>,
+{
+    type Response = R::Item;
+    type Error = S::Error;
+    type Future = future::AndThen<S::Future, R, F>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready()
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.service.call(req).and_then(self.f.clone())
+    }
+}

--- a/izanami-service/src/ext/err_into.rs
+++ b/izanami-service/src/ext/err_into.rs
@@ -1,0 +1,32 @@
+#![allow(missing_docs)]
+
+use {
+    crate::Service,
+    futures::{future, Future, Poll},
+    std::marker::PhantomData,
+};
+
+#[derive(Debug)]
+pub struct ErrInto<S, E> {
+    pub(super) service: S,
+    pub(super) _marker: PhantomData<fn() -> E>,
+}
+
+#[allow(clippy::type_complexity)]
+impl<S, E, Req> Service<Req> for ErrInto<S, E>
+where
+    S: Service<Req>,
+    S::Error: Into<E>,
+{
+    type Response = S::Response;
+    type Error = E;
+    type Future = future::MapErr<S::Future, fn(S::Error) -> E>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready().map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.service.call(req).map_err(Into::into)
+    }
+}

--- a/izanami-service/src/ext/map.rs
+++ b/izanami-service/src/ext/map.rs
@@ -1,0 +1,31 @@
+#![allow(missing_docs)]
+
+use {
+    crate::Service,
+    futures::{future, Future, Poll},
+};
+
+#[derive(Debug)]
+pub struct Map<S, F> {
+    pub(super) service: S,
+    pub(super) f: F,
+}
+
+impl<S, F, Res, Req> Service<Req> for Map<S, F>
+where
+    S: Service<Req>,
+    F: Fn(S::Response) -> Res + Clone,
+{
+    type Response = Res;
+    type Error = S::Error;
+    type Future = future::Map<S::Future, F>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready()
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let f = self.f.clone();
+        self.service.call(req).map(f)
+    }
+}

--- a/izanami-service/src/ext/map_err.rs
+++ b/izanami-service/src/ext/map_err.rs
@@ -1,0 +1,31 @@
+#![allow(missing_docs)]
+
+use {
+    crate::Service,
+    futures::{future, Future, Poll},
+};
+
+#[derive(Debug)]
+pub struct MapErr<S, F> {
+    pub(super) service: S,
+    pub(super) f: F,
+}
+
+impl<S, F, E, Req> Service<Req> for MapErr<S, F>
+where
+    S: Service<Req>,
+    F: Fn(S::Error) -> E + Clone,
+{
+    type Response = S::Response;
+    type Error = E;
+    type Future = future::MapErr<S::Future, F>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready().map_err(&self.f)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let f = self.f.clone();
+        self.service.call(req).map_err(f)
+    }
+}

--- a/izanami-service/src/lib.rs
+++ b/izanami-service/src/lib.rs
@@ -13,14 +13,20 @@
 )]
 #![forbid(clippy::unimplemented)]
 
+pub mod ext;
+
 mod into_service;
 mod make_service;
 mod service_fn;
 mod service_mut;
 mod service_ref;
+mod unit;
 
 #[doc(no_inline)]
-pub use tower_service::Service;
+pub use {
+    crate::ext::ServiceExt, //
+    tower_service::Service,
+};
 
 pub use crate::{
     into_service::IntoService, //
@@ -28,4 +34,5 @@ pub use crate::{
     service_fn::{service_fn, service_fn_ok},
     service_mut::ServiceMut,
     service_ref::ServiceRef,
+    unit::unit,
 };

--- a/izanami-service/src/unit.rs
+++ b/izanami-service/src/unit.rs
@@ -1,0 +1,26 @@
+use {
+    crate::Service,
+    futures::{Async, Poll},
+};
+
+/// Create a Service that returns `()`.
+pub fn unit() -> UnitService {
+    UnitService(())
+}
+
+#[derive(Debug)]
+pub struct UnitService(());
+
+impl<T> Service<T> for UnitService {
+    type Response = ();
+    type Error = std::io::Error; // FIXME: use never_type
+    type Future = futures::future::FutureResult<Self::Response, Self::Error>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(Async::Ready(()))
+    }
+
+    fn call(&mut self, _: T) -> Self::Future {
+        futures::future::ok(())
+    }
+}


### PR DESCRIPTION
This patch adds the ability to modify `Service`s by using combinators, that wraps a service and convert its result.
The idea is originated from `actix-service` and it may be completely replaced with `tower-middleware` in the future.
